### PR TITLE
afegir forwarders a view "internal" per a DNSForwarding

### DIFF
--- a/dnsservices.php
+++ b/dnsservices.php
@@ -537,8 +537,8 @@ class DNSservices {
       $dns->named();
       foreach ($xml->domains as $domains) {
         foreach ($domains->internal as $zones) {
-          $op = "\tmatch-clients { 127.0.0.1; 192.168.0.0/16; 10.0.0.0/8; 172.16.0.0/12; };\n\trecursion yes;\n\tinclude \"".$this->master_dir."/named.conf.int.private\";";
-          $this->view("", $op, $zones, $dns);
+          $op = "\tmatch-clients { 127.0.0.1; 192.168.0.0/16; 10.0.0.0/8; 172.16.0.0/12; };\n\trecursion yes;\n\tinclude \"".$this->master_dir."/named.conf.int.private\";\n\tforwarders { 109.69.8.196; 8.8.4.4; };";  
+	  $this->view("", $op, $zones, $dns);
         }
         foreach ($domains->external as $zones) {
           $op = "\tmatch-clients { any; };\n\trecursion no;\n\tinclude \"".$this->master_dir."/named.conf.ext.private\";";


### PR DESCRIPTION
Hola Miquel,

He fet un petit canvi al dnsservices que tenim a Mataró. He afegit que faci DNS Forwarding cap al servidor DNS de guifi (109.69.8.196), d'aquesta manera aconsegueixo:
- minimitzar trafic extern: ja que les peticions DNS es queden dins de la xarxa guifi.
- millor temps de resposta: al no haver de fer les peticions cap als root DNS, que sempre van més carregats.
- millors respostes: ara si fem un "nslookup google.com" respon amb varies adreces IP del campus nord. Abans, sense el dns forwarding, ho feia amb una sola IP  de Mountain View

Segurament es pugui millorar a nivell de configuració, que no posi la IP a pinyó, però això t'ho deixo per tu...

Salut!

Esteve
